### PR TITLE
Reserveer corona

### DIFF
--- a/src/client/contact/index.html
+++ b/src/client/contact/index.html
@@ -301,7 +301,7 @@
       <div class="col-xs-12 col-md-8">
         <div class="form-group">
           <label for="form_postcode">Bezorg postcode</label>
-          <input id="form_postcode" type="adress" name="adres" class="form-control" placeholder="" data-error="Voor het bezorgen hebben we ook je postcode nodig.">
+          <input id="form_postcode" type="adress" name="postcode" class="form-control" placeholder="" data-error="Voor het bezorgen hebben we ook je postcode nodig.">
           <div class="help-block with-errors"></div>
         </div>
       </div>

--- a/src/client/contact/index.html
+++ b/src/client/contact/index.html
@@ -291,12 +291,21 @@
     <div class="row">
       <div class="col-xs-12 col-md-8">
         <div class="form-group">
-          <label for="form_adress">Bezorg adres (straat, huisnummer & postcode)</label>
+          <label for="form_adress">Bezorg adres (straat, huisnummer)</label>
           <input id="form_adress" type="adress" name="adres" class="form-control" placeholder="" data-error="Als je wil dat we berzorgen, hebben we een adres nodig.">
           <div class="help-block with-errors"></div>
         </div>
       </div>
-    </div>            
+    </div>  
+    <div class="row">
+      <div class="col-xs-12 col-md-8">
+        <div class="form-group">
+          <label for="form_postcode">Bezorg postcode</label>
+          <input id="form_postcode" type="adress" name="adres" class="form-control" placeholder="" data-error="Voor het bezorgen hebben we ook je postcode nodig.">
+          <div class="help-block with-errors"></div>
+        </div>
+      </div>
+    </div>          
     <label class="honing" tabindex="-1" aria-hidden="true">
     <input type="text" name="petsName"></label>
     <button type="submit" class="btn-form">VERSTUUR</button>

--- a/src/client/reserveer/index.html
+++ b/src/client/reserveer/index.html
@@ -148,8 +148,8 @@
           <div class="row">
             <div class="col-md-12">
               <div class="form-group">
-                <input type="checkbox" id="Opsplitsen" name="Opsplitsen">
-                <label for="Opsplitsen"> Wij zijn <u>geen</u> huishouden</label>
+                <input type="checkbox" id="opsplitsen" name="opsplitsen">
+                <label for="opsplitsen"> Wij zijn <u>geen</u> huishouden</label>
               </div>
             </div>
           </div>

--- a/src/client/reserveer/index.html
+++ b/src/client/reserveer/index.html
@@ -104,8 +104,7 @@
     </div>
     <div class="container-s">
       <div class="container-black">
-        <!--<p>Alles gereserveerd? Helaas kunnen wij in deze tijd geen aanloop aannemen. </p>-->
-        <p>Vanaf 1 juni zijn we geopend. </p>
+        <p>Vanaf 1 juni zijn we weer geopend. </p>
       </div>
     </div> 
     <div class="container-s">
@@ -147,6 +146,14 @@
             </div>
           </div>
           <div class="row">
+            <div class="col-md-12">
+              <div class="form-group">
+                <input type="checkbox" id="Opsplitsen" name="Opsplitsen">
+                <label for="Opslitsen"> Wij zijn <u>geen</u> huishouden</label>
+              </div>
+            </div>
+          </div>
+          <div class="row">
             <div class="col-xs-12 col-md-12">
               <div class="form-group">
                 <label for="form_message">Zijn er allergieën of andere eetwensen waar we rekening mee moeten houden?</label>
@@ -177,6 +184,15 @@
               <div class="form-group">
                 <label for="form_phone">Telefoonnummer *</label>
                 <input id="form_phone" type="tel" name="phone" class="form-control" placeholder="" required="required" data-error="Als je wilt reserveren hebben we een telefoonnummer nodig.">
+                <div class="help-block with-errors"></div>
+              </div>
+            </div>
+          </div>
+          <div class="row">
+            <div class="col-md-12">
+              <div class="form-group">
+                <input type="checkbox" id="voorwaarden" name="voorwaarden" required="required" data-error="Graag aanvinken als je wilt reserveren">
+                <label for="voorwaarden"> Bij coronaklachten zullen we tijdig annuleren.*</label>
                 <div class="help-block with-errors"></div>
               </div>
             </div>

--- a/src/client/reserveer/index.html
+++ b/src/client/reserveer/index.html
@@ -149,7 +149,7 @@
             <div class="col-md-12">
               <div class="form-group">
                 <input type="checkbox" id="Opsplitsen" name="Opsplitsen">
-                <label for="Opslitsen"> Wij zijn <u>geen</u> huishouden</label>
+                <label for="Opsplitsen"> Wij zijn <u>geen</u> huishouden</label>
               </div>
             </div>
           </div>

--- a/src/server/functions/send-mail.js
+++ b/src/server/functions/send-mail.js
@@ -44,6 +44,7 @@ exports.handler = function (event, context, callback) {
 	const email = postData.email
 	const phone = postData.phone
 	const adres = postData.adres
+	const postcode = postData.postcode
 	const emailBody = getEmailBody(postData) 
 	const honeyPotValue = postData.petsName
 
@@ -81,7 +82,8 @@ exports.handler = function (event, context, callback) {
 		Naam: ${name}
 		E-mail: ${email}
 		Telefoon: ${phone}
-		Adres: ${adres}`
+		Adres: ${adres}
+		Postcode: ${postcode}`
 	}
 	const callbackHandler = {
 		statusCode: 302,


### PR DESCRIPTION
Ja ik vind dat ook lastig. Daan wilde het kort houden. Omdat, kort gezegd, als mensen geen huishouden zijn dan is dat meer hun verantwoordelijkheid om dat met ons te regelen. Ik kijk wel even hoe het gaat in de binnenkomende reserveringen, oke?

Zoals Daan heeft gevraagd, in reserveer formulier toegevoegd:
- checkbox voor: 'wij zijn geen huishouden'. Deze kunnen mensen aanvinken als ze bijv met 2 stellen komen.
- checkbox voor annuleren bij corona klachten. Ik heb deze required gemaakt met een error message.
- Ik heb niks toegevoegd in de send-mail-res omdat de nieuwe variabelen via de functie getEmailBody vanzelf erbij komen. 

In bestel formulier heb ik de postcode en straatnaam + nummer apart gemaakt. Omdat veel mensen hun postcode OF straatnaam niet gaven.

Ik heb getest via de netlify preview en ze werken. 

